### PR TITLE
Update winapi and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locale_config"
-version = "0.2.3-pre"
+version = "0.2.3"
 description = """
 Maintains locale preferences for process and thread and initialises them by
 inspecting the system for user preference.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ lazy_static = "1"
 regex = "1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.8"
-kernel32-sys = "0.2.2"
+winapi = { version = "0.3", features = ["winnls"] }
 
 [package.metadata.release]
 upload-doc = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate lazy_static;
 extern crate regex;
 
 use regex::Regex;
-use std::ascii::AsciiExt;
 use std::borrow::{Borrow,Cow};
 use std::cell::RefCell;
 use std::convert::AsRef;


### PR DESCRIPTION
I also removed a warning because of some deprecated imports that's been on stable for quite some time now.
I took the liberty of bumping the version as the crate seems pretty unmaintained but is used in the wild and duping quite a few (big) dependencies such as regex and winapi and it would be greate to get a new release out :) 