### PR TITLE
Add system locale detection on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ regex = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnls"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "^0.2"
+objc-foundation = "^0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ extern crate lazy_static;
 
 extern crate regex;
 
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+
 use regex::Regex;
 use std::borrow::{Borrow,Cow};
 use std::cell::RefCell;
@@ -709,11 +713,16 @@ mod win32;
 #[cfg(target_os = "emscripten")]
 mod emscripten;
 
+// macOS support
+#[cfg(target_os = "macos")]
+mod macos;
+
 static INITIALISERS: &'static [fn() -> Option<Locale>] = &[
     cgi::system_locale,
     unix::system_locale,
     #[cfg(target_family = "windows")] win32::system_locale,
     #[cfg(target_os = "emscripten")] emscripten::system_locale,
+	#[cfg(target_os = "macos")] macos::system_locale,
 ];
 
 fn system_locale() -> Locale {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,17 @@
+//! Inspect macOS system for locale configuration
+extern crate objc_foundation;
+
+use super::{LanguageRange, Locale};
+
+use objc::runtime::Object;
+use self::objc_foundation::{INSString, NSString};
+
+pub fn system_locale() -> Option<Locale> {
+	let locale_identifier = unsafe {
+		let nslocale = class!(NSLocale);
+		let current_locale: *mut Object = msg_send![nslocale, currentLocale];
+		let locale_identifier: *const NSString = msg_send![current_locale, localeIdentifier];
+		locale_identifier.as_ref().unwrap()
+	};
+	Some(Locale::from(LanguageRange::from_unix(locale_identifier.as_str()).unwrap()))
+}


### PR DESCRIPTION
This PR adds system locale detection on macOS as the environment variables used by unix mostly aren't set on macOS for some reason. This PR uses Objective-C bindings to determine the current locale.