### PR TITLE
Reduce compile time and transitive deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ appveyor = { repository = "rust-locale/locale_config" }
 
 [dependencies]
 lazy_static = "1"
-regex = "1"
+regex = { version = "1", default-features = false, features = [ "std", "unicode" ] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnls"] }


### PR DESCRIPTION
locale_config relies on regular expressions to parse input strings. The expressions are quite complex, but the input data is tiny. Furthermore, dealing with locales is unlikely to be in a hot loop. This lets us disable performance optimizations of the "regex" crate, which in turn drops some transitive dependencies and decreases the compile time of locale_config.

With these changes, `cargo +nightly build -Z timings --release` went down from 9.6 seconds to 5.8 seconds on my quad-core Intel i7-7700HQ: [before](https://github.com/rust-locale/locale_config/files/6207835/cargo-timing-20210325T204534Z.html.gz) vs [after](https://github.com/rust-locale/locale_config/files/6207837/cargo-timing-20210325T204647Z.html.gz).

If you'd like, I can add a new feature, "perf", which re-enables the "perf" feature on the "regex" crate. But I am personally not convinced that this is necessary.