### PR TITLE
Use `objc2` and `objc2-foundation`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,9 @@ regex = "1"
 winapi = { version = "0.3", features = ["winnls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc = "^0.2"
-objc-foundation = "^0.1"
+objc2 = "0.5.1"
+objc2-foundation = { version = "0.2", default-features = false, features = [
+    "std",
+    "NSLocale",
+    "NSString",
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,13 @@
 #[macro_use]
 extern crate lazy_static;
 
-extern crate regex;
+#[cfg(target_os = "macos")]
+extern crate objc2;
 
 #[cfg(target_os = "macos")]
-#[macro_use]
-extern crate objc;
+extern crate objc2_foundation;
+
+extern crate regex;
 
 use regex::Regex;
 use std::borrow::{Borrow,Cow};

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,17 +1,12 @@
 //! Inspect macOS system for locale configuration
-extern crate objc_foundation;
-
 use super::{LanguageRange, Locale};
 
-use objc::runtime::Object;
-use self::objc_foundation::{INSString, NSString};
+use objc2_foundation::NSLocale;
 
 pub fn system_locale() -> Option<Locale> {
-	let locale_identifier = unsafe {
-		let nslocale = class!(NSLocale);
-		let current_locale: *mut Object = msg_send![nslocale, currentLocale];
-		let locale_identifier: *const NSString = msg_send![current_locale, localeIdentifier];
-		locale_identifier.as_ref().unwrap()
-	};
-	Some(Locale::from(LanguageRange::from_unix(locale_identifier.as_str()).unwrap()))
+    let current_locale = unsafe { NSLocale::currentLocale() };
+    let locale_identifier = unsafe { current_locale.localeIdentifier() };
+    Some(Locale::from(
+        LanguageRange::from_unix(&locale_identifier.to_string()).unwrap(),
+    ))
 }


### PR DESCRIPTION
These crates are the successor crates to `objc` and `objc-foundation`.

Relevant to `locale_config` is that bindings to `NSLocale` is provided, avoiding the error-prone `msg_send!` macros.