### PR TITLE
Switch to lighter regex-lite crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ appveyor = { repository = "rust-locale/locale_config" }
 
 [dependencies]
 lazy_static = "1"
-regex = "1"
+regex-lite = "0.1.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winnls"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,14 @@
 #[macro_use]
 extern crate lazy_static;
 
-extern crate regex;
+extern crate regex_lite as regex;
 
 #[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;
 
 use regex::Regex;
-use std::borrow::{Borrow,Cow};
+use std::borrow::{Borrow, Cow};
 use std::cell::RefCell;
 use std::convert::AsRef;
 use std::fmt;
@@ -147,34 +147,46 @@ use std::sync::Mutex;
 /// [UN M.49]: https://en.wikipedia.org/wiki/UN_M.49
 /// [u_ext]: http://www.unicode.org/reports/tr35/#u_Extension
 /// [Language subtag registry]: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-#[derive(Clone,Debug,Eq,Hash,PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct LanguageRange<'a> {
-    language: Cow<'a, str>
+    language: Cow<'a, str>,
 }
 
 lazy_static! {
-    static ref REGULAR_LANGUAGE_RANGE_REGEX: Regex = Regex::new(r"(?x) ^
+    static ref REGULAR_LANGUAGE_RANGE_REGEX: Regex = Regex::new(
+        r"(?x) ^
         (?P<language> (?:
             [[:alpha:]]{2,3} (?: - [[:alpha:]]{3} ){0,3}
             | \* ))
         (?P<script> - (?: [[:alpha:]]{4} | \* ))?
         (?P<region> - (?: [[:alpha:]]{2} | [[:digit:]]{3} | \* ))?
         (?P<rest> (?: - (?: [[:alnum:]]{1,8} | \* ))*)
-    $ ").unwrap();
-    static ref LANGUAGE_RANGE_REGEX: Regex = Regex::new(r"(?x) ^
+    $ "
+    )
+    .unwrap();
+    static ref LANGUAGE_RANGE_REGEX: Regex = Regex::new(
+        r"(?x) ^
         (?: [[:alpha:]]{1,8} | \* )
         (?: - (?: [[:alnum:]]{1,8} | \* ))*
-    $ ").unwrap();
-    static ref UNIX_INVARIANT_REGEX: Regex = Regex::new(r"(?ix) ^
+    $ "
+    )
+    .unwrap();
+    static ref UNIX_INVARIANT_REGEX: Regex = Regex::new(
+        r"(?ix) ^
         (?: c | posix )
         (?: \. (?: [0-9a-zA-Z-]{1,20} ))?
-    $ ").unwrap();
-    static ref UNIX_TAG_REGEX: Regex = Regex::new(r"(?ix) ^
+    $ "
+    )
+    .unwrap();
+    static ref UNIX_TAG_REGEX: Regex = Regex::new(
+        r"(?ix) ^
         (?P<language> [[:alpha:]]{2,3} )
         (?: _  (?P<region> [[:alpha:]]{2} | [[:digit:]]{3} ))?
         (?: \. (?P<encoding> [0-9a-zA-Z-]{1,20} ))?
         (?: @  (?P<variant> [[:alnum:]]{1,20} ))?
-    $ ").unwrap();
+    $ "
+    )
+    .unwrap();
 }
 
 fn is_owned<'a, T: ToOwned + ?Sized>(c: &Cow<'a, T>) -> bool {
@@ -187,12 +199,13 @@ fn is_owned<'a, T: ToOwned + ?Sized>(c: &Cow<'a, T>) -> bool {
 fn canon_lower<'a>(o: Option<&'a str>) -> Cow<'a, str> {
     match o {
         None => Cow::Borrowed(""),
-        Some(s) =>
+        Some(s) => {
             if s.chars().any(char::is_uppercase) {
                 Cow::Owned(s.to_ascii_lowercase())
             } else {
                 Cow::Borrowed(s)
-            },
+            }
+        }
     }
 }
 
@@ -200,15 +213,19 @@ fn canon_script<'a>(o: Option<&'a str>) -> Cow<'a, str> {
     assert!(o.map_or(true, |s| s.len() >= 2 && &s[0..1] == "-"));
     match o {
         None => Cow::Borrowed(""),
-        Some(s) =>
-            if s[1..2].chars().next().unwrap().is_uppercase() &&
-               s[2..].chars().all(char::is_lowercase) {
+        Some(s) => {
+            if s[1..2].chars().next().unwrap().is_uppercase()
+                && s[2..].chars().all(char::is_lowercase)
+            {
                 Cow::Borrowed(s)
             } else {
-                Cow::Owned(String::from("-") +
-                           s[1..2].to_ascii_uppercase().as_ref() +
-                           s[2..].to_ascii_lowercase().as_ref())
-            },
+                Cow::Owned(
+                    String::from("-")
+                        + s[1..2].to_ascii_uppercase().as_ref()
+                        + s[2..].to_ascii_lowercase().as_ref(),
+                )
+            }
+        }
     }
 }
 
@@ -216,12 +233,13 @@ fn canon_upper<'a>(o: Option<&'a str>) -> Cow<'a, str> {
     assert!(o.map_or(true, |s| s.len() > 1 && &s[0..1] == "-"));
     match o {
         None => Cow::Borrowed(""),
-        Some(s) =>
+        Some(s) => {
             if s.chars().any(char::is_lowercase) {
                 Cow::Owned(s.to_ascii_uppercase())
             } else {
                 Cow::Borrowed(s)
-            },
+            }
+        }
     }
 }
 
@@ -248,17 +266,11 @@ impl<'a> LanguageRange<'a> {
             let script = canon_script(caps.name("script").map(|m| m.as_str()));
             let region = canon_upper(caps.name("region").map(|m| m.as_str()));
             let rest = canon_lower(caps.name("rest").map(|m| m.as_str()));
-            if is_owned(&language) ||
-                is_owned(&script) ||
-                is_owned(&region) ||
-                is_owned(&rest)
-            {
+            if is_owned(&language) || is_owned(&script) || is_owned(&region) || is_owned(&rest) {
                 return Ok(LanguageRange {
                     language: Cow::Owned(
-                        language.into_owned() +
-                        script.borrow() +
-                        region.borrow() +
-                        rest.borrow()),
+                        language.into_owned() + script.borrow() + region.borrow() + rest.borrow(),
+                    ),
                 });
             } else {
                 return Ok(LanguageRange {
@@ -278,20 +290,22 @@ impl<'a> LanguageRange<'a> {
     ///
     /// Invariant language is identified simply by empty string.
     pub fn invariant() -> LanguageRange<'static> {
-        LanguageRange { language: Cow::Borrowed("") }
+        LanguageRange {
+            language: Cow::Borrowed(""),
+        }
     }
 
     /// Clone the internal data to extend lifetime.
     pub fn into_static(self) -> LanguageRange<'static> {
         LanguageRange {
-            language: Cow::Owned(self.language.into_owned())
+            language: Cow::Owned(self.language.into_owned()),
         }
     }
 
     /// Create new instance sharing the internal data.
     pub fn to_shared(&'a self) -> Self {
         LanguageRange {
-            language: Cow::Borrowed(self.language.borrow())
+            language: Cow::Borrowed(self.language.borrow()),
         }
     }
 
@@ -310,22 +324,30 @@ impl<'a> LanguageRange<'a> {
     /// kind of tags from other sources than system configuration.
     pub fn from_unix(s: &str) -> Result<LanguageRange<'static>> {
         if let Some(caps) = UNIX_TAG_REGEX.captures(s) {
-            let src_variant = caps.name("variant").map(|m| m.as_str()).unwrap_or("").to_ascii_lowercase();
-            let mut res = caps.name("language").map(|m| m.as_str()).unwrap().to_ascii_lowercase();
+            let src_variant = caps
+                .name("variant")
+                .map(|m| m.as_str())
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            let mut res = caps
+                .name("language")
+                .map(|m| m.as_str())
+                .unwrap()
+                .to_ascii_lowercase();
             let region = caps.name("region").map(|m| m.as_str()).unwrap_or("");
             let mut script = "";
             let mut variant = "";
             let mut uvariant = "";
             match src_variant.as_ref() {
-            // Variants seen in the wild in GNU LibC (via http://lh.2xlibre.net/) or in Debian
-            // GNU/Linux Stretch system. Treatment of things not found in RFC5646 subtag registry
-            // (http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
-            // or CLDR according to notes at https://wiki.openoffice.org/wiki/LocaleMapping.
-            // Dialects:
+                // Variants seen in the wild in GNU LibC (via http://lh.2xlibre.net/) or in Debian
+                // GNU/Linux Stretch system. Treatment of things not found in RFC5646 subtag registry
+                // (http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)
+                // or CLDR according to notes at https://wiki.openoffice.org/wiki/LocaleMapping.
+                // Dialects:
                 // aa_ER@saaho - NOTE: Can't be found under that name in RFC5646 subtag registry,
                 // but there is language Saho with code ssy, which is likely that thing.
                 "saaho" if res == "aa" => res = String::from("ssy"),
-            // Scripts:
+                // Scripts:
                 // @arabic
                 "arabic" => script = "Arab",
                 // @cyrillic
@@ -345,27 +367,27 @@ impl<'a> LanguageRange<'a> {
                 "latin" => script = "Latn",
                 // en@shaw
                 "shaw" => script = "Shaw",
-            // Variants:
+                // Variants:
                 // sr@ijekavianlatin
                 "ijekavianlatin" => {
                     script = "Latn";
                     variant = "ijekavsk";
-                },
+                }
                 // sr@ije
                 "ije" => variant = "ijekavsk",
                 // sr@ijekavian
                 "ijekavian" => variant = "ijekavsk",
                 // ca@valencia
                 "valencia" => variant = "valencia",
-            // Currencies:
+                // Currencies:
                 // @euro - NOTE: We follow suite of Java and Openoffice and ignore it, because it
                 // is default for all locales where it sometimes appears now, and because we use
                 // explicit currency in monetary formatting anyway.
-                "euro" => {},
-            // Collation:
+                "euro" => {}
+                // Collation:
                 // gez@abegede - NOTE: This is collation, but CLDR does not have any code for it,
                 // so we for the moment leave it fall through as -u-va- instead of -u-co-.
-            // Anything else:
+                // Anything else:
                 // en@boldquot, en@quot, en@piglatin - just randomish stuff
                 // @cjknarrow - beware, it's gonna end up as -u-va-cjknarro due to lenght limit
                 s if s.len() <= 8 => uvariant = &*s,
@@ -388,10 +410,10 @@ impl<'a> LanguageRange<'a> {
                 res.push_str(uvariant);
             }
             return Ok(LanguageRange {
-                language: Cow::Owned(res)
+                language: Cow::Owned(res),
             });
         } else if UNIX_INVARIANT_REGEX.is_match(s) {
-            return Ok(LanguageRange::invariant())
+            return Ok(LanguageRange::invariant());
         } else {
             return Err(Error::NotWellFormed);
         }
@@ -439,7 +461,7 @@ impl<'a> fmt::Display for LanguageRange<'a> {
 /// Note that a syntactically valid value of HTTP `Accept-Language` header is a valid `Locale`. Not
 /// the other way around though due to the presence of category selectors.
 // TODO: Interning
-#[derive(Clone,Debug,Eq,Hash,PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Locale {
     // TODO: Intern the string for performance reasons
     // XXX: Store pre-split to LanguageTags?
@@ -447,10 +469,13 @@ pub struct Locale {
 }
 
 lazy_static! {
-    static ref LOCALE_ELEMENT_REGEX: Regex = Regex::new(r"(?ix) ^
+    static ref LOCALE_ELEMENT_REGEX: Regex = Regex::new(
+        r"(?ix) ^
         (?: (?P<category> [[:alpha:]]{1,20} ) = )?
         (?P<tag> (?: [[:alnum:]] | - | \* )+ )
-    $ ").unwrap();
+    $ "
+    )
+    .unwrap();
 }
 
 impl Locale {
@@ -497,13 +522,13 @@ impl Locale {
     /// _overrides_ for those categories and the remaining tags indicate fallbacks.
     pub fn new(s: &str) -> Result<Locale> {
         let mut i = s.split(',');
-        let mut res = Locale::from(
-            try!(LanguageRange::new(
-                    i.next().unwrap()))); // NOTE: split "" is (""), not ()
+        let mut res = Locale::from(try!(LanguageRange::new(i.next().unwrap()))); // NOTE: split "" is (""), not ()
         for t in i {
             if let Some(caps) = LOCALE_ELEMENT_REGEX.captures(t) {
-                let tag = try!(LanguageRange::new(
-                        try!(caps.name("tag").map(|m| m.as_str()).ok_or(Error::NotWellFormed))));
+                let tag = try!(LanguageRange::new(try!(caps
+                    .name("tag")
+                    .map(|m| m.as_str())
+                    .ok_or(Error::NotWellFormed))));
                 match caps.name("category").map(|m| m.as_str()) {
                     Some(cat) => res.add_category(cat.to_ascii_lowercase().as_ref(), &tag),
                     None => res.add(&tag),
@@ -544,9 +569,10 @@ impl Locale {
             return; // don't add useless override equal to the primary tag
         }
         for i in self.inner.split(',') {
-            if i.starts_with(category) &&
-                    i[category.len()..].starts_with("=") &&
-                    &i[category.len() + 1..] == tag.as_ref() {
+            if i.starts_with(category)
+                && i[category.len()..].starts_with("=")
+                && &i[category.len() + 1..] == tag.as_ref()
+            {
                 return; // don't add duplicates
             }
         }
@@ -563,7 +589,9 @@ impl Locale {
     ///
     /// The iterator is guaranteed to return at least one value.
     pub fn tags<'a>(&'a self) -> Tags<'a> {
-        Tags { tags: self.inner.split(","), }
+        Tags {
+            tags: self.inner.split(","),
+        }
     }
 
     /// Iterate over `LanguageRange`s in this `Locale` applicable to given category.
@@ -633,11 +661,17 @@ impl<'a> Iterator for Tags<'a> {
             if let Some(i) = s.find('=') {
                 return Some((
                     Some(&s[..i]),
-                    LanguageRange { language: Cow::Borrowed(&s[i+1..]), }));
+                    LanguageRange {
+                        language: Cow::Borrowed(&s[i + 1..]),
+                    },
+                ));
             } else {
                 return Some((
                     None,
-                    LanguageRange { language: Cow::Borrowed(s), }));
+                    LanguageRange {
+                        language: Cow::Borrowed(s),
+                    },
+                ));
             }
         } else {
             return None;
@@ -664,8 +698,9 @@ impl<'a, 'c> Iterator for TagsFor<'a, 'c> {
         if let Some(cat) = self.category {
             while let Some(s) = self.tags.next() {
                 if s.starts_with(cat) && s[cat.len()..].starts_with("=") {
-                    return Some(
-                        LanguageRange { language: Cow::Borrowed(&s[cat.len()+1..]) });
+                    return Some(LanguageRange {
+                        language: Cow::Borrowed(&s[cat.len() + 1..]),
+                    });
                 }
             }
             self.category = None;
@@ -673,8 +708,9 @@ impl<'a, 'c> Iterator for TagsFor<'a, 'c> {
         }
         while let Some(s) = self.tags.next() {
             if s.find('=').is_none() {
-                return Some(
-                    LanguageRange{ language: Cow::Borrowed(s) });
+                return Some(LanguageRange {
+                    language: Cow::Borrowed(s),
+                });
             }
         }
         return None;
@@ -720,9 +756,12 @@ mod macos;
 static INITIALISERS: &'static [fn() -> Option<Locale>] = &[
     cgi::system_locale,
     unix::system_locale,
-    #[cfg(target_family = "windows")] win32::system_locale,
-    #[cfg(target_os = "emscripten")] emscripten::system_locale,
-	#[cfg(target_os = "macos")] macos::system_locale,
+    #[cfg(target_family = "windows")]
+    win32::system_locale,
+    #[cfg(target_os = "emscripten")]
+    emscripten::system_locale,
+    #[cfg(target_os = "macos")]
+    macos::system_locale,
 ];
 
 fn system_locale() -> Locale {
@@ -737,7 +776,7 @@ fn system_locale() -> Locale {
 // --------------------------------- ERRORS ------------------------------------
 
 /// Errors that may be returned by `locale_config`.
-#[derive(Copy,Clone,Debug,PartialEq,Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Provided definition was not well formed.
     ///
@@ -752,7 +791,7 @@ pub enum Error {
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, out: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        use ::std::error::Error;
+        use std::error::Error;
         out.write_str(self.description())
     }
 }
@@ -775,9 +814,9 @@ type Result<T> = ::std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod test {
+    use super::is_owned;
     use super::LanguageRange;
     use super::Locale;
-    use super::is_owned;
     use std::iter::FromIterator;
 
     #[test]
@@ -785,7 +824,10 @@ mod test {
         assert_eq!("en-US", LanguageRange::new("en-US").unwrap().as_ref());
         assert_eq!("en-US", LanguageRange::new("EN-US").unwrap().as_ref());
         assert_eq!("en", LanguageRange::new("en").unwrap().as_ref());
-        assert_eq!("eng-Latn-840", LanguageRange::new("eng-Latn-840").unwrap().as_ref());
+        assert_eq!(
+            "eng-Latn-840",
+            LanguageRange::new("eng-Latn-840").unwrap().as_ref()
+        );
         assert_eq!("english", LanguageRange::new("English").unwrap().as_ref());
     }
 
@@ -794,18 +836,36 @@ mod test {
         assert_eq!("*", LanguageRange::new("*").unwrap().as_ref());
         assert_eq!("zh-*", LanguageRange::new("zh-*").unwrap().as_ref());
         assert_eq!("zh-*-CN", LanguageRange::new("zh-*-cn").unwrap().as_ref());
-        assert_eq!("en-*-simple-*", LanguageRange::new("En-*-Simple-*").unwrap().as_ref());
-        assert_eq!("zh-Hans-*", LanguageRange::new("zh-hans-*").unwrap().as_ref());
+        assert_eq!(
+            "en-*-simple-*",
+            LanguageRange::new("En-*-Simple-*").unwrap().as_ref()
+        );
+        assert_eq!(
+            "zh-Hans-*",
+            LanguageRange::new("zh-hans-*").unwrap().as_ref()
+        );
     }
 
     #[test]
     fn complex_valid_lang_ranges() {
-        assert_eq!("de-DE-u-email-co-phonebk-x-linux",
-                   LanguageRange::new("de-DE-u-email-co-phonebk-x-linux").unwrap().as_ref());
-        assert_eq!("vi-VN-u-fw-mon-hc-h24-ms-metric",
-                   LanguageRange::new("vi-vn-u-fw-mon-hc-h24-ms-metric").unwrap().as_ref());
-        assert_eq!("sl-Cyrl-YU-rozaj-solba-1994-b-1234-a-foobar-x-b-1234-a-foobar",
-                   LanguageRange::new("sl-Cyrl-YU-rozaj-solba-1994-b-1234-a-Foobar-x-b-1234-a-Foobar").unwrap().as_ref());
+        assert_eq!(
+            "de-DE-u-email-co-phonebk-x-linux",
+            LanguageRange::new("de-DE-u-email-co-phonebk-x-linux")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "vi-VN-u-fw-mon-hc-h24-ms-metric",
+            LanguageRange::new("vi-vn-u-fw-mon-hc-h24-ms-metric")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "sl-Cyrl-YU-rozaj-solba-1994-b-1234-a-foobar-x-b-1234-a-foobar",
+            LanguageRange::new("sl-Cyrl-YU-rozaj-solba-1994-b-1234-a-Foobar-x-b-1234-a-Foobar")
+                .unwrap()
+                .as_ref()
+        );
     }
 
     #[test]
@@ -834,8 +894,12 @@ mod test {
         // Check that the string is not copied if the tag is canonical
         assert!(!is_owned(&LanguageRange::new("en-US").unwrap().language));
         assert!(!is_owned(&LanguageRange::new("en").unwrap().language));
-        assert!(!is_owned(&LanguageRange::new("zh-Hant-CN").unwrap().language));
-        assert!(!is_owned(&LanguageRange::new("cs-CZ-x-ds-002e").unwrap().language));
+        assert!(!is_owned(
+            &LanguageRange::new("zh-Hant-CN").unwrap().language
+        ));
+        assert!(!is_owned(
+            &LanguageRange::new("cs-CZ-x-ds-002e").unwrap().language
+        ));
         assert!(!is_owned(&LanguageRange::new("czech").unwrap().language));
     }
 
@@ -850,17 +914,29 @@ mod test {
 
     #[test]
     fn locale_list() {
-        assert_eq!("cs-CZ,en-GB,en,*", Locale::new("cs-cz,en-gb,en,*").unwrap().as_ref());
-        assert_eq!("cs-CZ,engrish", Locale::new("cs-cz,engrish").unwrap().as_ref());
+        assert_eq!(
+            "cs-CZ,en-GB,en,*",
+            Locale::new("cs-cz,en-gb,en,*").unwrap().as_ref()
+        );
+        assert_eq!(
+            "cs-CZ,engrish",
+            Locale::new("cs-cz,engrish").unwrap().as_ref()
+        );
         assert!(Locale::new("cs-cz,hı-İN").is_err());
     }
 
     #[test]
     fn locale_category() {
-        assert_eq!("cs-CZ,messages=en-GB",
-                   Locale::new("cs-CZ,messages=en-GB").unwrap().as_ref());
-        assert_eq!("zh-Hant,time=ja-JP,measurement=en-US",
-                   Locale::new("zh-hant,TIME=ja-jp,meaSURement=en-US").unwrap().as_ref());
+        assert_eq!(
+            "cs-CZ,messages=en-GB",
+            Locale::new("cs-CZ,messages=en-GB").unwrap().as_ref()
+        );
+        assert_eq!(
+            "zh-Hant,time=ja-JP,measurement=en-US",
+            Locale::new("zh-hant,TIME=ja-jp,meaSURement=en-US")
+                .unwrap()
+                .as_ref()
+        );
         // the first item must be plain language tag
         assert!(Locale::new("messages=pl").is_err());
         // adding general alternate should not help
@@ -869,49 +945,105 @@ mod test {
 
     #[test]
     fn locale_dups() {
-        assert_eq!("cs-CZ,en,de-AT", Locale::new("cs-CZ,en,de-AT,en").unwrap().as_ref());
-        assert_eq!("en-US,en", Locale::new("en-us,en-US,EN,eN-Us,en").unwrap().as_ref());
+        assert_eq!(
+            "cs-CZ,en,de-AT",
+            Locale::new("cs-CZ,en,de-AT,en").unwrap().as_ref()
+        );
+        assert_eq!(
+            "en-US,en",
+            Locale::new("en-us,en-US,EN,eN-Us,en").unwrap().as_ref()
+        );
     }
 
     #[test]
     fn locale_category_dups() {
-        assert_eq!("cs-CZ",
-                   Locale::new("cs-CZ,messages=cs-CZ,time=cs-cz,collate=CS-cz").unwrap().as_ref());
-        assert_eq!("de-AT,en-AU",
-                   Locale::new("de-AT,en-AU,messages=de-AT").unwrap().as_ref());
+        assert_eq!(
+            "cs-CZ",
+            Locale::new("cs-CZ,messages=cs-CZ,time=cs-cz,collate=CS-cz")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "de-AT,en-AU",
+            Locale::new("de-AT,en-AU,messages=de-AT").unwrap().as_ref()
+        );
         // category overrides override, so don't drop if they are only equal to alternates
-        assert_eq!("de-AT,en-AU,messages=en-AU",
-                   Locale::new("de-AT,en-AU,messages=en-AU").unwrap().as_ref());
-        assert_eq!("hi-IN,time=en-IN",
-                   Locale::new("hi-IN,time=en-IN,TIME=EN-in,TiMe=En-iN").unwrap().as_ref());
+        assert_eq!(
+            "de-AT,en-AU,messages=en-AU",
+            Locale::new("de-AT,en-AU,messages=en-AU").unwrap().as_ref()
+        );
+        assert_eq!(
+            "hi-IN,time=en-IN",
+            Locale::new("hi-IN,time=en-IN,TIME=EN-in,TiMe=En-iN")
+                .unwrap()
+                .as_ref()
+        );
     }
 
     #[test]
     fn unix_tags() {
-        assert_eq!("cs-CZ", LanguageRange::from_unix("cs_CZ.UTF-8").unwrap().as_ref());
-        assert_eq!("sr-RS-ijekavsk", LanguageRange::from_unix("sr_RS@ijekavian").unwrap().as_ref());
-        assert_eq!("sr-Latn-ijekavsk", LanguageRange::from_unix("sr.UTF-8@ijekavianlatin").unwrap().as_ref());
-        assert_eq!("en-Arab", LanguageRange::from_unix("en@arabic").unwrap().as_ref());
-        assert_eq!("en-Arab", LanguageRange::from_unix("en.UTF-8@arabic").unwrap().as_ref());
-        assert_eq!("de-DE", LanguageRange::from_unix("DE_de.UTF-8@euro").unwrap().as_ref());
-        assert_eq!("ssy-ER", LanguageRange::from_unix("aa_ER@saaho").unwrap().as_ref());
+        assert_eq!(
+            "cs-CZ",
+            LanguageRange::from_unix("cs_CZ.UTF-8").unwrap().as_ref()
+        );
+        assert_eq!(
+            "sr-RS-ijekavsk",
+            LanguageRange::from_unix("sr_RS@ijekavian")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "sr-Latn-ijekavsk",
+            LanguageRange::from_unix("sr.UTF-8@ijekavianlatin")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "en-Arab",
+            LanguageRange::from_unix("en@arabic").unwrap().as_ref()
+        );
+        assert_eq!(
+            "en-Arab",
+            LanguageRange::from_unix("en.UTF-8@arabic")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "de-DE",
+            LanguageRange::from_unix("DE_de.UTF-8@euro")
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            "ssy-ER",
+            LanguageRange::from_unix("aa_ER@saaho").unwrap().as_ref()
+        );
         assert!(LanguageRange::from_unix("foo_BAR").is_err());
         assert!(LanguageRange::from_unix("en@arabic.UTF-8").is_err());
         assert_eq!("", LanguageRange::from_unix("C").unwrap().as_ref());
         assert_eq!("", LanguageRange::from_unix("C.UTF-8").unwrap().as_ref());
-        assert_eq!("", LanguageRange::from_unix("C.ISO-8859-1").unwrap().as_ref());
+        assert_eq!(
+            "",
+            LanguageRange::from_unix("C.ISO-8859-1").unwrap().as_ref()
+        );
         assert_eq!("", LanguageRange::from_unix("POSIX").unwrap().as_ref());
     }
 
     #[test]
     fn category_tag_list() {
         assert_eq!(
-            Vec::from_iter(Locale::new("cs-CZ,messages=en-GB,time=de-DE,collate=en-US").unwrap().tags()),
-            &[(None, LanguageRange::new("cs-CZ").unwrap()),
-              (Some("messages"), LanguageRange::new("en-GB").unwrap()),
-              (Some("time"), LanguageRange::new("de-DE").unwrap()),
-              (Some("collate"), LanguageRange::new("en-US").unwrap()),
-            ]);
+            Vec::from_iter(
+                Locale::new("cs-CZ,messages=en-GB,time=de-DE,collate=en-US")
+                    .unwrap()
+                    .tags()
+            ),
+            &[
+                (None, LanguageRange::new("cs-CZ").unwrap()),
+                (Some("messages"), LanguageRange::new("en-GB").unwrap()),
+                (Some("time"), LanguageRange::new("de-DE").unwrap()),
+                (Some("collate"), LanguageRange::new("en-US").unwrap()),
+            ]
+        );
     }
 
     #[test]
@@ -919,23 +1051,29 @@ mod test {
         let locale = Locale::new("cs-CZ,messages=en-GB,time=de-DE,sk-SK,pl-PL").unwrap();
         assert_eq!(
             Vec::from_iter(locale.tags_for("messages")),
-            &[LanguageRange::new("en-GB").unwrap(),
-              LanguageRange::new("cs-CZ").unwrap(),
-              LanguageRange::new("sk-SK").unwrap(),
-              LanguageRange::new("pl-PL").unwrap(),
-            ]);
+            &[
+                LanguageRange::new("en-GB").unwrap(),
+                LanguageRange::new("cs-CZ").unwrap(),
+                LanguageRange::new("sk-SK").unwrap(),
+                LanguageRange::new("pl-PL").unwrap(),
+            ]
+        );
         assert_eq!(
             Vec::from_iter(locale.tags_for("time")),
-            &[LanguageRange::new("de-DE").unwrap(),
-              LanguageRange::new("cs-CZ").unwrap(),
-              LanguageRange::new("sk-SK").unwrap(),
-              LanguageRange::new("pl-PL").unwrap(),
-            ]);
+            &[
+                LanguageRange::new("de-DE").unwrap(),
+                LanguageRange::new("cs-CZ").unwrap(),
+                LanguageRange::new("sk-SK").unwrap(),
+                LanguageRange::new("pl-PL").unwrap(),
+            ]
+        );
         assert_eq!(
             Vec::from_iter(locale.tags_for("measurement")),
-            &[LanguageRange::new("cs-CZ").unwrap(),
-              LanguageRange::new("sk-SK").unwrap(),
-              LanguageRange::new("pl-PL").unwrap(),
-            ]);
+            &[
+                LanguageRange::new("cs-CZ").unwrap(),
+                LanguageRange::new("sk-SK").unwrap(),
+                LanguageRange::new("pl-PL").unwrap(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
I have been monitoring my dependency tree and I noticed this crate is the only in it which has regex as dependency. The regex crate significantly increases binary size and compile times. Furthermore this crate only uses ASCII character classes, so the additional Unicode support is not relevant.

Only 2 lines have been semantically changed, the rest is formatting.